### PR TITLE
🎨 Palette: Fix semantic heading hierarchy in Latest Post card

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -45,3 +45,7 @@
 ## 2026-03-01 - External Links and Interactive Icons
 **Learning:** Setting `aria-hidden="true"` on custom external link icons prevents screen readers from announcing that the link opens in a new tab. Additionally, using only `hover` classes on interactive icons within a link omits keyboard users from seeing the same visual interactions.
 **Action:** Always assign `role="img"` and `aria-label="(opens in new tab)"` to SVG icons indicating external links. Furthermore, apply equivalent `focus-visible` classes to any hover interactions inside interactive elements to ensure visual feedback parity for keyboard users.
+
+## 2026-03-05 - Semantic Heading Hierarchy
+**Learning:** Hardcoding heading levels (like `<h3>`) inside reusable components (such as a card) often causes accessibility violations when the component is placed sequentially after the same or a higher heading level (e.g., following another `<h3>`). This creates confusing navigation for screen reader users expecting logical hierarchy.
+**Action:** Always maintain semantic structure by ensuring that headings inside nested components or cards are properly incremented relative to their parent container's heading.

--- a/src/components/HomepageContent/index.js
+++ b/src/components/HomepageContent/index.js
@@ -93,12 +93,12 @@ function LatestPost() {
         <h3>Latest Update</h3>
         <div className="card shadow--md">
           <div className="card__header">
-            <h3>
+            <h4>
               <Link to={latestPost.url} className="inline-flex items-center gap-1 group">
                 {latestPost.title}
                 <ArrowIcon className="transition-transform group-hover:translate-x-1 group-focus-visible:translate-x-1" />
               </Link>
-            </h3>
+            </h4>
             <small>
               <time dateTime={latestPost.date}>
                 {new Date(latestPost.date).toLocaleDateString('en-US', {


### PR DESCRIPTION
💡 What: Fixed semantic heading hierarchy in the Latest Update card on the homepage by changing the nested `<h3>` tag to an `<h4>` tag. Added a critical UX learning about semantic headings to `.Jules/palette.md`.
🎯 Why: Having an `<h3>` immediately inside another section already introduced with an `<h3>` ("Latest Update") disrupts the logical document outline, creating confusing navigation for screen reader users expecting correct semantic hierarchy. Changing it to `<h4>` restores parity.
📸 Before/After: See attached screenshot of the correct heading placement.
♿ Accessibility: Improved semantic HTML hierarchy by ensuring headings are properly incremented, avoiding accessibility violations for screen readers.

---
*PR created automatically by Jules for task [922177666261906777](https://jules.google.com/task/922177666261906777) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the semantic heading hierarchy in the homepage Latest Update card by changing the nested post title from `<h3>` to `<h4>`, aligning it under the existing `<h3>` and improving screen reader navigation. Adds an accessibility note to `.Jules/palette.md` to avoid hardcoded heading levels in reusable components.

<sup>Written for commit 97f922b2da7e3ce5f0b9b20b97a2162dca3de8cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

