### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix reverse tabnabbing on external links

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Python `requests` (and similar libraries) will happily stream any content type, allowing attackers to force a crawler to download and process unexpected binary files or large data streams.
 **Learning:** Scripts that fetch content (like for embeddings or metadata) often check size limits but neglect `Content-Type`. This can waste resources or trigger errors in parsers.
 **Prevention:** Always validate `Content-Type` headers against a strict allowlist (e.g., `text/html`, `application/xml`) *before* iterating over the response content.
+
+## 2025-02-21 - Reverse Tabnabbing in Dynamic Links
+**Vulnerability:** External links created dynamically without `target="_blank"` and `rel="noopener noreferrer"` can allow the newly opened tab to access the `window.opener` object, leading to potential phishing attacks via reverse tabnabbing. Additionally, omitting `noreferrer` leaks referer information.
+**Learning:** React components that conditionally render links as internal or external based on the URL often neglect to conditionally apply the correct `target` and `rel` attributes.
+**Prevention:** Always ensure dynamic link components evaluate whether a link is external and explicitly apply `target="_blank"` and `rel="noopener noreferrer"`.

--- a/src/components/HomepageContent/index.js
+++ b/src/components/HomepageContent/index.js
@@ -61,7 +61,12 @@ function Section({ title, items }) {
                 <div style={{ marginBottom: '0.25rem' }}>
                   <strong>
                     {item.link ? (
-                      <Link to={item.link} className="inline-flex items-center gap-1 group">
+                      <Link
+                        to={item.link}
+                        className="inline-flex items-center gap-1 group"
+                        target={isExternal ? "_blank" : undefined}
+                        rel={isExternal ? "noopener noreferrer" : undefined}
+                      >
                         {item.title}
                         {isExternal ? (
                           <ExternalLinkIcon className="transition-transform group-hover:translate-x-1 group-hover:-translate-y-1 group-focus-visible:translate-x-1 group-focus-visible:-translate-y-1" />


### PR DESCRIPTION
🚨 **Severity:** MEDIUM

💡 **Vulnerability:** External links created dynamically in `HomepageContent/index.js` did not explicitly set `target="_blank"` or `rel="noopener noreferrer"`. This could allow the newly opened external site to access the `window.opener` object, potentially leading to a reverse tabnabbing attack where the attacker changes the original page to a phishing site. Additionally, omitting `noreferrer` leaked referer information to external sites.

🎯 **Impact:** Potential phishing via malicious redirects on the original tab, and minor privacy leakage via the Referer header.

🔧 **Fix:** Updated the `Link` component generation logic to conditionally evaluate the `isExternal` boolean and apply `target="_blank"` and `rel="noopener noreferrer"` accordingly. 

✅ **Verification:** Verified that external links in the Homepage Content now render with `target="_blank" rel="noopener noreferrer"` via a Playwright test. Also verified the build succeeds and no regressions were introduced. Added learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [9481431023995986913](https://jules.google.com/task/9481431023995986913) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes reverse tabnabbing by setting safe attributes on external links in the homepage. Prevents opener access and referer leaks when opening external sites.

- **Bug Fixes**
  - In `src/components/HomepageContent/index.js`, apply `target="_blank"` and `rel="noopener noreferrer"` when `isExternal` is true; internal links remain unchanged.
  - Added a security note to `.jules/sentinel.md` documenting the issue and prevention.

<sup>Written for commit 7bc72742088278bcea2c45a810d731d3e3e734e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

