### PR TITLE
🎨 Palette: Update heading level for Latest Update card

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -45,3 +45,7 @@
 ## 2026-03-01 - External Links and Interactive Icons
 **Learning:** Setting `aria-hidden="true"` on custom external link icons prevents screen readers from announcing that the link opens in a new tab. Additionally, using only `hover` classes on interactive icons within a link omits keyboard users from seeing the same visual interactions.
 **Action:** Always assign `role="img"` and `aria-label="(opens in new tab)"` to SVG icons indicating external links. Furthermore, apply equivalent `focus-visible` classes to any hover interactions inside interactive elements to ensure visual feedback parity for keyboard users.
+
+## 2026-03-02 - Semantic Heading Levels in Components
+**Learning:** Hardcoding heading levels (e.g., `<h3>`) in reusable component structures like cards can break semantic navigation if the component is nested under another heading of the same or lower level.
+**Action:** Ensure nested headings inside components properly increment relative to their parent container's heading level (e.g., using `<h4>` under an `<h3>`) to maintain accessibility.

--- a/src/components/HomepageContent/index.js
+++ b/src/components/HomepageContent/index.js
@@ -93,12 +93,12 @@ function LatestPost() {
         <h3>Latest Update</h3>
         <div className="card shadow--md">
           <div className="card__header">
-            <h3>
+            <h4>
               <Link to={latestPost.url} className="inline-flex items-center gap-1 group">
                 {latestPost.title}
                 <ArrowIcon className="transition-transform group-hover:translate-x-1 group-focus-visible:translate-x-1" />
               </Link>
-            </h3>
+            </h4>
             <small>
               <time dateTime={latestPost.date}>
                 {new Date(latestPost.date).toLocaleDateString('en-US', {


### PR DESCRIPTION
### 💡 What:
Updated the `<h3>` tag in the `LatestPost` card's header to an `<h4>`. Also added an entry to `.Jules/palette.md` noting the importance of semantic heading hierarchies in reusable components.

### 🎯 Why:
The "Latest Update" section already uses an `<h3>` heading. Having the nested card's title also be an `<h3>` breaks the logical document outline and semantic navigation structure for screen reader users, who rely on heading levels to understand context.

### 📸 Before/After:
The visual presentation has not changed because the class-based styling handles the appearance. However, the raw HTML now correctly nests the post title `<h4>` under the section title `<h3>`.

### ♿ Accessibility:
Improved semantic HTML hierarchy for screen reader navigation by ensuring headings increment logically.

---
*PR created automatically by Jules for task [17558020667341023800](https://jules.google.com/task/17558020667341023800) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the nested post title in the homepage "Latest Update" card from `<h3>` to `<h4>` to keep a correct heading hierarchy under the section’s `<h3>`. Improves screen reader navigation with no visual changes, and adds a note on semantic headings to `.Jules/palette.md`.

<sup>Written for commit ad3c200358e8ead473495781f357c9ae83621fdd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

