### PR TITLE
🎨 Palette: Fix heading hierarchy in nested UI cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -45,3 +45,7 @@
 ## 2026-03-01 - External Links and Interactive Icons
 **Learning:** Setting `aria-hidden="true"` on custom external link icons prevents screen readers from announcing that the link opens in a new tab. Additionally, using only `hover` classes on interactive icons within a link omits keyboard users from seeing the same visual interactions.
 **Action:** Always assign `role="img"` and `aria-label="(opens in new tab)"` to SVG icons indicating external links. Furthermore, apply equivalent `focus-visible` classes to any hover interactions inside interactive elements to ensure visual feedback parity for keyboard users.
+
+## 2026-03-29 - Heading Hierarchy in Nested UI Components
+**Learning:** Using hardcoded `<h3>` tags for titles inside reusable cards can break semantic heading hierarchy if the card is placed within another `<h3>` section, confusing screen reader users who navigate by headings.
+**Action:** Avoid hardcoding generic heading levels inside cards; ensure headings properly increment relative to their parent container, e.g., using `<h4>` when nested inside an `<h3>` section.

--- a/src/components/HomepageContent/index.js
+++ b/src/components/HomepageContent/index.js
@@ -93,12 +93,12 @@ function LatestPost() {
         <h3>Latest Update</h3>
         <div className="card shadow--md">
           <div className="card__header">
-            <h3>
+            <h4>
               <Link to={latestPost.url} className="inline-flex items-center gap-1 group">
                 {latestPost.title}
                 <ArrowIcon className="transition-transform group-hover:translate-x-1 group-focus-visible:translate-x-1" />
               </Link>
-            </h3>
+            </h4>
             <small>
               <time dateTime={latestPost.date}>
                 {new Date(latestPost.date).toLocaleDateString('en-US', {


### PR DESCRIPTION
💡 **What:** Changed the `<h3>` wrapping the post title inside the "Latest Update" card to an `<h4>` in `src/components/HomepageContent/index.js`.
🎯 **Why:** To improve semantic heading hierarchy. The "Latest Update" section itself is an `<h3>`. Nesting another `<h3>` immediately inside it for the card title disrupts the logical document outline, making it confusing for screen reader users navigating by headings.
♿ **Accessibility:** This directly improves accessibility by ensuring heading levels correctly increment, allowing screen readers to accurately represent the relationship between the section and its contents.
📝 **Journal Entry:** A new critical learning regarding heading hierarchy in nested UI components was added to `.Jules/palette.md`.

---
*PR created automatically by Jules for task [14610081192161817067](https://jules.google.com/task/14610081192161817067) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the heading hierarchy in the “Latest Update” card by changing the post title from h3 to h4. This keeps the outline under the section’s h3 and improves screen reader navigation.

<sup>Written for commit 6e264518e6f8be0bbf36521ac907bf95cded0b11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

