### PR TITLE
⚡ Bolt: Optimize `generate-latest-post.js` performance with two-pass algorithm

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@ This journal documents critical performance learnings for the 5L Labs project.
 ## 2026-02-22 - Font Loading Optimization
 **Learning:** Using `preconnect` for `fonts.gstatic.com` significantly improves FCP by establishing the connection early.
 **Action:** Always include `preconnect` links for external font providers in `docusaurus.config.js`.
+
+## 2026-02-23 - Build Script O(N) Read Optimization
+**Learning:** Build scripts that iterate chronologically over files (like finding the latest post) can suffer from O(N) I/O and parsing overhead if they indiscriminately read and parse every file that is newer than the *current* maximum.
+**Action:** When finding the newest file, use a two-pass algorithm. First pass: iterate over directory listings and identify the target file using only filenames (and regex matches on dates in the filename). Second pass: perform expensive file reads (`fs.readFileSync`) and parsing (e.g., `gray-matter`) *only* on the single target file.

--- a/scripts/generate-latest-post.js
+++ b/scripts/generate-latest-post.js
@@ -42,8 +42,15 @@ function stripMarkdown(markdown) {
 
 function getLatestPost() {
     let latestPost = null;
+    let latestPostMeta = null;
     const DATE_REGEX = /^(\d{4})-(\d{2})-(\d{2})/;
 
+    // ⚡ Bolt: Two-pass algorithm optimization.
+    // Instead of reading and parsing frontmatter for every file that happens to be newer
+    // than the current max during iteration, we first find the single newest file by just
+    // examining filenames (O(1) memory, O(1) reads). Then we read and parse ONLY that file.
+
+    // First pass: find the newest file path and its metadata
     BLOG_DIRS.forEach(dir => {
         const dirPath = path.join(__dirname, '..', dir);
         if (!fs.existsSync(dirPath)) return;
@@ -59,39 +66,54 @@ function getLatestPost() {
             const [_, yearStr, monthStr, dayStr] = match;
             const date = new Date(`${yearStr}-${monthStr}-${dayStr}`);
 
-            if (!latestPost || date > latestPost.date) {
-                const content = fs.readFileSync(path.join(dirPath, file), 'utf-8');
-                const { data, content: markdownContent } = matter(content);
-
-                let postContent = '';
-                if (data.description) {
-                    postContent = data.description;
-                } else {
-                    postContent = stripMarkdown(markdownContent);
-                }
-
-                const truncated = postContent.length > 550 ? postContent.substring(0, 550) + '...' : postContent;
-
-                const slug = data.slug || file.replace(/^\d{4}-\d{2}-\d{2}-/, '').replace(/\.(md|mdx)$/, '');
-
-                const routeBasePath = dir.replace('blog-', '');
-
-                let url;
-                if (data.slug) {
-                    url = `/${routeBasePath}/${data.slug}`;
-                } else {
-                    url = `/${routeBasePath}/${yearStr}/${monthStr}/${dayStr}/${slug}`;
-                }
-
-                latestPost = {
-                    date: date,
-                    title: data.title || slug,
-                    content: truncated,
-                    url: url
+            if (!latestPostMeta || date > latestPostMeta.date) {
+                latestPostMeta = {
+                    date,
+                    file,
+                    dirPath,
+                    dir,
+                    yearStr,
+                    monthStr,
+                    dayStr
                 };
             }
         });
     });
+
+    // Second pass: read and parse ONLY the newest file discovered
+    if (latestPostMeta) {
+        const { date, file, dirPath, dir, yearStr, monthStr, dayStr } = latestPostMeta;
+
+        const content = fs.readFileSync(path.join(dirPath, file), 'utf-8');
+        const { data, content: markdownContent } = matter(content);
+
+        let postContent = '';
+        if (data.description) {
+            postContent = data.description;
+        } else {
+            postContent = stripMarkdown(markdownContent);
+        }
+
+        const truncated = postContent.length > 550 ? postContent.substring(0, 550) + '...' : postContent;
+
+        const slug = data.slug || file.replace(/^\d{4}-\d{2}-\d{2}-/, '').replace(/\.(md|mdx)$/, '');
+
+        const routeBasePath = dir.replace('blog-', '');
+
+        let url;
+        if (data.slug) {
+            url = `/${routeBasePath}/${data.slug}`;
+        } else {
+            url = `/${routeBasePath}/${yearStr}/${monthStr}/${dayStr}/${slug}`;
+        }
+
+        latestPost = {
+            date: date,
+            title: data.title || slug,
+            content: truncated,
+            url: url
+        };
+    }
 
     return latestPost;
 }


### PR DESCRIPTION
⚡ **What:** 
Re-wrote `scripts/generate-latest-post.js` to implement a two-pass algorithm.
First pass: Identifies the latest blog post by evaluating just the filenames and paths without opening any files.
Second pass: Performs a single I/O read `fs.readFileSync` and markdown parser operation `matter()` strictly on the identified target post.

🎯 **Why:** 
The original script performed synchronously sequential I/O and frontmatter parsing on every single post file that happened to be more recent than the prior maximum in an iteration. This created a massive performance overhead in directories with numerous ordered items, resulting in O(N) file system calls and block delays during `bun run build`. 

📊 **Impact:** 
Reduces disk read operations from O(N) dependent on sorting order to exactly O(1) file read/parse during the extraction of the latest post. This drastically speeds up both `start` and `build` commands for large or heavily-populated blog repos.

🔬 **Measurement:** 
Run `bun run scripts/generate-latest-post.js` locally on a machine with a heavily populated directory (or artificially populate a mock directory) and measure execution time or I/O system calls using `strace` or standard profiling. Alternatively, run `bun run build` and observe the "Build preparation complete." delay before Docusaurus begins standard site aggregation.

---
*PR created automatically by Jules for task [377610626140408433](https://jules.google.com/task/377610626140408433) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up latest-post generation by switching `scripts/generate-latest-post.js` to a two-pass algorithm that reads and parses only one file. This cuts disk reads from O(N) to O(1) and reduces build time for large blogs.

- **Refactors**
  - First pass scans filenames to find the newest post; second pass reads/parses only that file with `gray-matter`.
  - Added a performance note to `.jules/bolt.md` documenting the two-pass approach.

<sup>Written for commit 8d1f4a1698b50d74aadcd04ca213e354dd2dcb31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

