### PR TITLE
Docs: Update Privacy Policy and add legal section to footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -221,8 +221,17 @@ const config = {
                 href: "https://www.linkedin.com/company/5l-labs/",
               },
               {
-                label: "Twitter",
-                href: "https://twitter.com/5l_labs",
+              label: "Twitter",
+              href: "https://twitter.com/5l_labs",
+            },
+          ],
+        },
+          {
+            title: "Legal",
+            items: [
+              {
+                label: "Privacy Policy",
+                to: "/privacy-policy",
               },
             ],
           },

--- a/src/pages/privacy-policy.md
+++ b/src/pages/privacy-policy.md
@@ -1,0 +1,53 @@
+---
+title: Privacy Policy
+---
+
+# Privacy Policy
+
+**Last Updated:** March 22, 2025
+
+---
+
+*   **Our Privacy Commitment**
+    *   5L Labs, LLC is dedicated to protecting your privacy while you visit [5l-labs.com](https://5l-labs.com).
+    *   Our operations are guided by three pillars: **Privacy First**, **Data Minimalism**, and **Total Transparency**.
+
+<br/>
+
+*   **1. Analytics & Tracking (Google Analytics)**
+    *   **Service:** We use Google Analytics (ID: `G-P85W9ZNZTP`) to understand site traffic and improve content.
+    *   **IP Anonymization:** We have explicitly enabled `anonymizeIP`. Your full IP address is **never** stored by Google.
+    *   **Data Scope:** We only see anonymized metrics such as pages visited, time on site, and general device categories.
+    *   **Your Control:** You may opt-out of all tracking by using a browser extension or by disabling cookies in your settings.
+
+<br/>
+
+*   **2. Information You Provide (PII)**
+    *   **Voluntary Collection:** We do **not** collect personally identifiable information (PII) automatically.
+    *   **Direct Contact:** When you email [inquiries@5l-labs.com](mailto:inquiries@5l-labs.com), we receive your address and any details you provide.
+    *   **Purpose:** Your information is used **solely** to respond to your specific inquiry.
+    *   **Protection:** we do **not** sell, rent, or share your PII with third parties for their own marketing purposes.
+
+<br/>
+
+*   **3. Data Retention Policies**
+    *   **Automated Data:** Analytics data is retained according to Google's standard cycles and is automatically deleted thereafter.
+    *   **Business Records:** Emails and direct communications are retained as part of our **permanent business records** for reference, legal, and operational purposes.
+    *   **Minimalist Storage:** We do not maintain separate databases of user profiles or tracking records.
+
+<br/>
+
+*   **4. Cookies & Third-Party Links**
+    *   **Cookies:** Our site uses cookies for the analytics functions noted above. You can disable these at any time.
+    *   **External Links:** We are not responsible for the privacy practices of third-party sites we link to (e.g., GitHub, LinkedIn).
+    *   **Future Integrations:** If we add third-party sign-in (e.g., Google/GitHub), we will only request the minimum profile data needed for authentication.
+
+<br/>
+
+*   **5. Contacting Us**
+    *   **Email:** Reach us at [inquiries@5l-labs.com](mailto:inquiries@5l-labs.com) with any questions regarding this policy.
+    *   **Location:** 5L Labs, LLC is based in New York, NY.
+
+---
+
+<p align="center"><em>Operated with privacy as a priority.</em></p>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Privacy Policy page at /privacy-policy and a "Legal" footer section linking to it, making the policy easy to find.

<sup>Written for commit 5b0cf40a4f2ce5f95dea284266e30f685f52e17d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

