### PR TITLE
🎨 Palette: Fix heading hierarchy in Latest Update card

### DIFF
--- a/src/components/HomepageContent/index.js
+++ b/src/components/HomepageContent/index.js
@@ -93,12 +93,12 @@ function LatestPost() {
         <h3>Latest Update</h3>
         <div className="card shadow--md">
           <div className="card__header">
-            <h3>
+            <h4>
               <Link to={latestPost.url} className="inline-flex items-center gap-1 group">
                 {latestPost.title}
                 <ArrowIcon className="transition-transform group-hover:translate-x-1 group-focus-visible:translate-x-1" />
               </Link>
-            </h3>
+            </h4>
             <small>
               <time dateTime={latestPost.date}>
                 {new Date(latestPost.date).toLocaleDateString('en-US', {


### PR DESCRIPTION
💡 What: Changed the Latest Post title heading from `<h3>` to `<h4>` in the `LatestPost` card inside `src/components/HomepageContent/index.js`.
🎯 Why: To fix the heading hierarchy for screen reader accessibility, as the parent container already uses an `<h3>` heading (`<h3>Latest Update</h3>`). Properly nesting headings allows screen-reader users to navigate the document structure logically.
📸 Before/After: N/A (non-visual structural change; visual presentation remains consistent within the Docusaurus styling system).
♿ Accessibility: Fixes a screen reader heading level violation by ensuring proper heading incrementation.

---
*PR created automatically by Jules for task [14921173149292404428](https://jules.google.com/task/14921173149292404428) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix heading hierarchy in the Latest Update card by changing the Latest Post title from <h3> to <h4> so it nests under the existing <h3>. Improves screen reader navigation; no visual changes.

<sup>Written for commit 508b2e03de1dc44cfc9aebb3245ec5258c2c4a3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

