### PR TITLE
🎨 Palette: [UX improvement] Fix heading hierarchy for screen reader navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -45,3 +45,7 @@
 ## 2026-03-01 - External Links and Interactive Icons
 **Learning:** Setting `aria-hidden="true"` on custom external link icons prevents screen readers from announcing that the link opens in a new tab. Additionally, using only `hover` classes on interactive icons within a link omits keyboard users from seeing the same visual interactions.
 **Action:** Always assign `role="img"` and `aria-label="(opens in new tab)"` to SVG icons indicating external links. Furthermore, apply equivalent `focus-visible` classes to any hover interactions inside interactive elements to ensure visual feedback parity for keyboard users.
+
+## 2026-03-05 - Heading Hierarchy in Components
+**Learning:** Reusable components like cards shouldn't hardcode absolute heading levels like `<h3>` as it can break heading hierarchy and confuse screen readers if placed within a section already containing an `<h3>`.
+**Action:** Always ensure nested headings properly increment relative to their parent container's heading. Wait, since it's hard to make generic components context-aware without extra props, make sure heading hierarchy flows well in context of usage.

--- a/src/components/HomepageContent/index.js
+++ b/src/components/HomepageContent/index.js
@@ -93,12 +93,12 @@ function LatestPost() {
         <h3>Latest Update</h3>
         <div className="card shadow--md">
           <div className="card__header">
-            <h3>
+            <h4>
               <Link to={latestPost.url} className="inline-flex items-center gap-1 group">
                 {latestPost.title}
                 <ArrowIcon className="transition-transform group-hover:translate-x-1 group-focus-visible:translate-x-1" />
               </Link>
-            </h3>
+            </h4>
             <small>
               <time dateTime={latestPost.date}>
                 {new Date(latestPost.date).toLocaleDateString('en-US', {


### PR DESCRIPTION
💡 **What:** Replaced the `<h3>` wrapping the Latest Update post title inside `HomepageContent/index.js` with an `<h4>`. Also documented this learning in `.Jules/palette.md`.
🎯 **Why:** To improve semantic HTML and correct the heading hierarchy. Previously, the title was an `<h3>` following another `<h3>` ("Latest Update"), which confuses screen reader navigation.
📸 **Before/After:** No visual differences intended; visually verified using Playwright.
♿ **Accessibility:** Corrects the heading nesting hierarchy, allowing screen reader users to properly navigate the section hierarchy.

---
*PR created automatically by Jules for task [3011376454775645529](https://jules.google.com/task/3011376454775645529) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve screen reader navigation by fixing the heading hierarchy in the homepage Latest Update card. Change the post title from <h3> to <h4> (no visual changes) and add guidance to `.Jules/palette.md` on avoiding hardcoded heading levels in reusable components.

<sup>Written for commit 3630caa3ce0d2b3cb4ed115f7c222ca6c494812d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

