### PR TITLE
🎨 Palette: [UX improvement] Fix heading hierarchy in LatestPost

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -45,3 +45,7 @@
 ## 2026-03-01 - External Links and Interactive Icons
 **Learning:** Setting `aria-hidden="true"` on custom external link icons prevents screen readers from announcing that the link opens in a new tab. Additionally, using only `hover` classes on interactive icons within a link omits keyboard users from seeing the same visual interactions.
 **Action:** Always assign `role="img"` and `aria-label="(opens in new tab)"` to SVG icons indicating external links. Furthermore, apply equivalent `focus-visible` classes to any hover interactions inside interactive elements to ensure visual feedback parity for keyboard users.
+
+## 2026-03-02 - Nested Heading Hierarchy in Components
+**Learning:** Hardcoding heading levels (like `<h3>`) in reusable components or cards can break the semantic document outline if the component is nested inside another element that already uses that heading level. For example, a card title shouldn't use the same heading level as the section that contains the card. This causes screen readers to misinterpret the structure.
+**Action:** Ensure nested headings properly increment relative to their parent container's heading, or use a more dynamic heading level approach if the component is highly reusable.

--- a/src/components/HomepageContent/index.js
+++ b/src/components/HomepageContent/index.js
@@ -93,12 +93,12 @@ function LatestPost() {
         <h3>Latest Update</h3>
         <div className="card shadow--md">
           <div className="card__header">
-            <h3>
+            <h4>
               <Link to={latestPost.url} className="inline-flex items-center gap-1 group">
                 {latestPost.title}
                 <ArrowIcon className="transition-transform group-hover:translate-x-1 group-focus-visible:translate-x-1" />
               </Link>
-            </h3>
+            </h4>
             <small>
               <time dateTime={latestPost.date}>
                 {new Date(latestPost.date).toLocaleDateString('en-US', {


### PR DESCRIPTION
💡 What: Changed the nested heading in LatestPost from h3 to h4.
🎯 Why: To ensure properly incremented heading levels, preventing the card title from sharing the same heading level as its parent section.
📸 Before/After: Visual structure unchanged.
♿ Accessibility: Improves screen reader navigation by maintaining a logical, hierarchical document outline.

---
*PR created automatically by Jules for task [12027171687157674627](https://jules.google.com/task/12027171687157674627) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the heading hierarchy in LatestPost by changing the card title from h3 to h4 so the section title remains higher and screen readers get a logical outline. No visual changes.

- **Bug Fixes**
  - Updated `LatestPost` to render the card title as `<h4>` under the "Latest Update" `<h3>`.
  - Added notes to `.Jules/palette.md` on choosing heading levels inside reusable components.

<sup>Written for commit 3e685b9571e894bb3f431fdcebd0bac375e45a73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

