### PR TITLE
🎨 Palette: Fix heading hierarchy in LatestPost component

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -50,3 +50,7 @@
 
 **Learning:** When dynamically rendering `<Link>` components, simply inserting attributes like `target="_blank"` or `aria-label` inside a loop can accidentally pollute internal links with external behaviors or unnecessary labels.
 **Action:** Use an object spread with a conditional (e.g., `{...(isExternal ? { target: "_blank", rel: "noopener noreferrer", "aria-label": \`\${title} (opens in a new tab)\`, title: title } : {})}`) to apply specific accessibility and behavioral attributes only when appropriate, keeping the DOM clean and accessible.
+
+## 2026-04-26 - Hardcoded Heading Levels in Reusable Components
+**Learning:** Hardcoding specific heading levels (like `<h3>`) inside reusable UI components (like cards) often breaks semantic document structure when the component is placed in different contexts on a page, causing screen readers to skip levels or announce confusing hierarchies.
+**Action:** Always ensure nested headings (like card titles) properly increment relative to their parent container's heading level, or consider passing the appropriate heading level as a prop to the component to maintain strict HTML semantics.

--- a/src/components/HomepageContent/index.js
+++ b/src/components/HomepageContent/index.js
@@ -104,12 +104,12 @@ function LatestPost() {
         <h3>Latest Update</h3>
         <div className="card shadow--md">
           <div className="card__header">
-            <h3>
+            <h4>
               <Link to={latestPost.url} className="inline-flex items-center gap-1 group">
                 {latestPost.title}
                 <ArrowIcon className="transition-transform group-hover:translate-x-1 group-focus-visible:translate-x-1" />
               </Link>
-            </h3>
+            </h4>
             <small>
               <time dateTime={latestPost.date}>
                 {new Date(latestPost.date).toLocaleDateString('en-US', {


### PR DESCRIPTION
What: Changed the hardcoded \`<h3>\` to \`<h4>\` in the LatestPost card header.
Why: The LatestPost section title is an \`<h3>\`, so the nested card title should be an \`<h4>\` to maintain correct document structure.
Before/After: The visual appearance relies on Docusaurus/Tailwind inherited styles but semantically, the HTML hierarchy is now strictly valid.
Accessibility: Improves screen reader navigation by ensuring heading levels increment sequentially without skipping or inappropriate repeating.

---
*PR created automatically by Jules for task [14034401034108109253](https://jules.google.com/task/14034401034108109253) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix heading hierarchy in `LatestPost` by changing the card title from `h3` to `h4`, matching the section’s `h3` and improving screen reader navigation. Updates `.Jules/palette.md` with guidance to avoid hardcoded heading levels in reusable components and to pass the level as a prop when needed.

<sup>Written for commit d57735cf861b1cf31fe3d756041f166ac70959c7. Summary will update on new commits. <a href="https://cubic.dev/pr/5L-Labs/5l-labs.com/pull/99?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

