### PR TITLE
🎨 Palette: [UX improvement] Enhance keyboard navigation and screen reader experience

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -54,3 +54,6 @@
 ## 2026-04-26 - Hardcoded Heading Levels in Reusable Components
 **Learning:** Hardcoding specific heading levels (like `<h3>`) inside reusable UI components (like cards) often breaks semantic document structure when the component is placed in different contexts on a page, causing screen readers to skip levels or announce confusing hierarchies.
 **Action:** Always ensure nested headings (like card titles) properly increment relative to their parent container's heading level, or consider passing the appropriate heading level as a prop to the component to maintain strict HTML semantics.
+## 2024-05-03 - Redundant Link Icons Announcement
+**Learning:** Decorative icons indicating external or internal links (like `↗`) that are appended to already readable links cause frustrating redundant screen reader announcements (e.g., reading "North East Arrow" immediately after reading the link text) and create confusing double tab-stops if wrapped in separate interactive elements.
+**Action:** Always add `aria-hidden="true"` to decorative link icons or elements. If an icon must be inside its own link but points to the same destination as a preceding adjacent text link, also add `tabIndex="-1"` to prevent it from receiving keyboard focus, streamlining navigation.

--- a/src/pages/archive.js
+++ b/src/pages/archive.js
@@ -75,7 +75,7 @@ export default function Archive() {
                 <th>TYPE</th>
                 <th className={styles.hideOnMobile}>AREA</th>
                 <th>TITLE</th>
-                <th>↗</th>
+                <th aria-hidden="true">↗</th>
               </tr>
             </thead>
             <tbody>
@@ -95,7 +95,7 @@ export default function Archive() {
                   <td className={styles.colTitle}>
                     <Link to={entry.url}>{entry.title}</Link>
                   </td>
-                  <td><Link to={entry.url}>↗</Link></td>
+                  <td><Link to={entry.url} aria-hidden="true" tabIndex="-1">↗</Link></td>
                 </tr>
               ))}
             </tbody>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -78,7 +78,7 @@ export default function Home() {
                 <th>TYPE</th>
                 <th className={styles.hideOnMobile}>AREA</th>
                 <th>TITLE</th>
-                <th>↗</th>
+                <th aria-hidden="true">↗</th>
               </tr>
             </thead>
             <tbody>
@@ -98,7 +98,7 @@ export default function Home() {
                   <td className={styles.colTitle}>
                     <Link to={entry.url}>{entry.title}</Link>
                   </td>
-                  <td><Link to={entry.url}>↗</Link></td>
+                  <td><Link to={entry.url} aria-hidden="true" tabIndex="-1">↗</Link></td>
                 </tr>
               ))}
             </tbody>
@@ -124,7 +124,7 @@ export default function Home() {
                   <Link to={p.link} className={styles.projectName}>
                     {p.title.toLowerCase().replace(/\s*\(.*?\)/, '')}
                   </Link>
-                  <span className={styles.projectMeta}>↗</span>
+                  <span className={styles.projectMeta} aria-hidden="true">↗</span>
                 </div>
                 <div className={styles.projectDesc}>{p.description}</div>
               </div>

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -115,6 +115,14 @@
   cursor: pointer;
   white-space: nowrap;
 }
+.chip:hover {
+  opacity: 0.8;
+}
+.chip:focus-visible {
+  outline: 2px solid var(--brand-primary);
+  outline-offset: 2px;
+}
+
 .chipActive {
   border-color: var(--brand-primary);
   color: var(--brand-primary);
@@ -193,6 +201,11 @@
   box-shadow: 3px 3px 0 rgba(0,0,0,0.2);
 }
 .btnAccent:hover { color: #fff; opacity: 0.9; text-decoration: none; }
+.btnAccent:focus-visible {
+  outline: 2px solid var(--brand-primary);
+  outline-offset: 2px;
+}
+
 
 @media (max-width: 768px) {
   .page { padding: 32px 20px 60px; }

--- a/src/pages/inquiry.module.css
+++ b/src/pages/inquiry.module.css
@@ -112,6 +112,11 @@
   box-shadow: none;
 }
 .submit:not(:disabled):hover { opacity: 0.9; }
+.submit:focus-visible {
+  outline: 2px solid var(--brand-primary);
+  outline-offset: 2px;
+}
+
 
 .errorMsg {
   font-size: 13px;


### PR DESCRIPTION
💡 What: Added hover/focus states to chips and buttons, and hid redundant ↗ icons from screen readers. 🎯 Why: Improves keyboard accessibility and prevents screen readers from redundantly announcing 'North East Arrow'. ♿ Accessibility: Improved focus indicators and screen reader experience.

---
*PR created automatically by Jules for task [12830172526683879274](https://jules.google.com/task/12830172526683879274) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves keyboard navigation and screen reader behavior by adding clear focus styles to chips and buttons and treating `↗` link icons as decorative. Updates Archive and Home pages to prevent duplicate announcements and tab stops.

- **New Features**
  - Added `:focus-visible` outlines to `.chip`, `.btnAccent`, and `.submit`; added `:hover` to `.chip`.
  - Set `aria-hidden="true"` on `↗` icons and `tabIndex="-1"` on duplicate link icons; updated headers and links in `archive.js` and `index.js`.
  - Documented guidance in `.Jules/palette.md` on hiding decorative link icons from assistive tech.

<sup>Written for commit e431ddcb6ab437044e09e24b09dcd23fd77766fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

