### PR TITLE
🎨 Palette: Expand project hit areas and improve hover states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -57,3 +57,7 @@
 ## 2024-05-03 - Redundant Link Icons Announcement
 **Learning:** Decorative icons indicating external or internal links (like `↗`) that are appended to already readable links cause frustrating redundant screen reader announcements (e.g., reading "North East Arrow" immediately after reading the link text) and create confusing double tab-stops if wrapped in separate interactive elements.
 **Action:** Always add `aria-hidden="true"` to decorative link icons or elements. If an icon must be inside its own link but points to the same destination as a preceding adjacent text link, also add `tabIndex="-1"` to prevent it from receiving keyboard focus, streamlining navigation.
+
+## 2026-05-10 - Expanding Hit Areas for Block Elements
+**Learning:** Having only text as the clickable area within a larger logical block (like a project listing or card) violates Fitts's Law and frustrates mobile users who try to tap the area around the text.
+**Action:** Always wrap the entire logical block in a `<Link>` (or `<a>` tag) and apply `display: block` to expand the interactive hit area. Pair this with hover and `:focus-visible` styles on the entire block, and use transforms on trailing icons (e.g., `↗`) to provide clear visual affordance.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -118,17 +118,32 @@ export default function Home() {
 
           <div className={styles.box}>
             <div className={styles.boxLabel}>~/projects</div>
-            {homepageConfig.products.map((p) => (
-              <div key={p.title} className={styles.projectGroup}>
-                <div className={styles.projectRow}>
-                  <Link to={p.link} className={styles.projectName}>
-                    {p.title.toLowerCase().replace(/\s*\(.*?\)/, '')}
-                  </Link>
-                  <span className={styles.projectMeta} aria-hidden="true">↗</span>
-                </div>
-                <div className={styles.projectDesc}>{p.description}</div>
-              </div>
-            ))}
+            {homepageConfig.products.map((p) => {
+              const isExternal = p.link && p.link.startsWith('http');
+              return (
+                <Link
+                  key={p.title}
+                  to={p.link}
+                  className={styles.projectGroupLink}
+                  {...(isExternal
+                    ? {
+                        target: "_blank",
+                        rel: "noopener noreferrer",
+                        "aria-label": `${p.title} (opens in a new tab)`,
+                        title: p.title,
+                      }
+                    : {})}
+                >
+                  <div className={styles.projectRow}>
+                    <span className={styles.projectName}>
+                      {p.title.toLowerCase().replace(/\s*\(.*?\)/, '')}
+                    </span>
+                    <span className={styles.projectMeta} aria-hidden="true">↗</span>
+                  </div>
+                  <div className={styles.projectDesc}>{p.description}</div>
+                </Link>
+              );
+            })}
           </div>
 
           <div className={styles.box}>

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -148,11 +148,24 @@
   margin-bottom: 14px;
 }
 
-.projectGroup {
+.projectGroupLink {
+  display: block;
+  text-decoration: none;
   padding: 10px 0;
   border-bottom: 1px dashed color-mix(in srgb, var(--text-muted) 30%, transparent);
 }
-.projectGroup:last-child { border-bottom: none; padding-bottom: 0; }
+.projectGroupLink:last-child { border-bottom: none; padding-bottom: 0; }
+.projectGroupLink:hover .projectName { color: var(--brand-primary); }
+.projectGroupLink:focus-visible {
+  outline: 2px solid var(--brand-primary);
+  outline-offset: 4px;
+  border-radius: 2px;
+}
+.projectGroupLink:hover .projectMeta,
+.projectGroupLink:focus-visible .projectMeta {
+  transform: translate(2px, -2px);
+  color: var(--brand-primary);
+}
 
 .projectRow {
   display: flex;
@@ -161,10 +174,14 @@
   font-size: 14px;
   margin-bottom: 3px;
 }
-.projectName { color: var(--text-main); text-decoration: none; }
-.projectName:hover { color: var(--brand-primary); }
-.projectMeta { color: var(--text-muted); font-size: 12px; }
-.projectDesc { font-size: 12px; color: var(--text-muted); }
+.projectName { color: var(--text-main); text-decoration: none; transition: color 0.2s ease; }
+.projectMeta {
+  color: var(--text-muted);
+  font-size: 12px;
+  display: inline-block;
+  transition: transform 0.2s ease, color 0.2s ease;
+}
+.projectDesc { font-size: 12px; color: var(--text-muted); transition: color 0.2s ease; }
 
 .consultTitle {
   font-family: var(--font-mono);


### PR DESCRIPTION
### 💡 What: Expanded project hit areas to cover the entire container block and added interactive hover/focus animations to the external link icons.

### 🎯 Why: To improve tap-ability for mobile users (Fitts's Law) and provide better visual affordance.

### 📸 Before/After: Visual hit area is now the entire row instead of just the text.

### ♿ Accessibility: Added proper focus-visible states for keyboard users and aria-labels for external links.

---
*PR created automatically by Jules for task [6288665008460032200](https://jules.google.com/task/6288665008460032200) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded the project list so each item is a single clickable block with clear hover/focus feedback for better tap targets and accessibility. External links now open in a new tab with accessible labels, and the "↗" icon animates on interaction.

- **New Features**
  - Each project item is now a block-level link wrapping the title and description.
  - Added focus-visible outline and hover color changes; the trailing "↗" icon shifts and tints on hover/focus.
  - External links use target="_blank", rel="noopener noreferrer", and `aria-label` for better screen reader support.
  - Palette docs updated with guidance on expanding hit areas and styling focus states.

<sup>Written for commit 74def4f512fd5a09aad31925249938695d650c6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

