### PR TITLE
🎨 Palette: Expand index table hit areas

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -61,3 +61,7 @@
 ## 2026-05-10 - Expanding Hit Areas for Block Elements
 **Learning:** Having only text as the clickable area within a larger logical block (like a project listing or card) violates Fitts's Law and frustrates mobile users who try to tap the area around the text.
 **Action:** Always wrap the entire logical block in a `<Link>` (or `<a>` tag) and apply `display: block` to expand the interactive hit area. Pair this with hover and `:focus-visible` styles on the entire block, and use transforms on trailing icons (e.g., `↗`) to provide clear visual affordance.
+
+## 2026-05-18 - Expanding Hit Areas for Table Rows
+**Learning:** Having only text as the clickable area within a table row violates Fitts's Law. Wrapping an entire `<tr>` in an `<a>` or `<Link>` tag is invalid HTML and breaks semantic document structure.
+**Action:** Use relative positioned rows (`position: relative` on `tr`) and absolute positioned `::after` pseudo-elements (`inset: 0; position: absolute; z-index: 1`) on the primary link to safely expand the interactive hit area. Pair this with `:focus-within` styles on the entire row and `z-index: 2` on secondary interactive elements within the row.

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -72,9 +72,11 @@
 .indexTable thead th:last-child { text-align: right; }
 
 .indexTable tbody tr {
+  position: relative;
   border-bottom: 1px dashed color-mix(in srgb, var(--text-muted) 30%, transparent);
 }
 .indexTable tbody tr:hover { background: color-mix(in srgb, var(--text-muted) 8%, transparent); }
+.indexTable tbody tr:focus-within { outline: 2px solid var(--brand-primary); outline-offset: -2px; }
 
 .indexTable tbody td {
   padding: 10px 6px;
@@ -92,8 +94,25 @@
   color: var(--text-main);
   text-decoration: none;
 }
+.indexTable tbody td.colTitle a::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
 .indexTable tbody td.colTitle a:hover { color: var(--brand-primary); }
 .indexTable tbody td:last-child { text-align: right; }
+.indexTable tbody td:last-child a {
+  display: inline-block;
+  transition: transform 0.2s ease, color 0.2s ease;
+  z-index: 2;
+  position: relative;
+}
+.indexTable tbody tr:hover td:last-child a,
+.indexTable tbody tr:focus-within td:last-child a {
+  transform: translate(2px, -2px);
+  color: var(--brand-primary);
+}
 
 .loadMore {
   text-align: center;


### PR DESCRIPTION
💡 **What:** Expanded the clickable hit area of the index tables (on `/` and `/archive`) to cover the entire row instead of just the title text, using a CSS-only approach.

🎯 **Why:** Having only text as the clickable area within a table row violates Fitts's Law and frustrates mobile users who try to tap the area around the text. Because wrapping a `<tr>` in an `<a>` tag is invalid HTML, this uses an absolutely positioned `::after` pseudo-element on the primary link, scoped to a relatively positioned row.

📸 **Before/After:** The hit area now covers the entire row width/height. A new `:focus-within` blue outline has been added for keyboard users.

♿ **Accessibility:** Improved Fitts's Law compliance for mobile/mouse users. Added distinct focus-ring styling using `:focus-within` when a user tabs onto the row's primary link. Secondary links (like the ↗ icon) are positioned above (`z-index: 2`) the pseudo-element to maintain their independent clickability and tab-order.

---
*PR created automatically by Jules for task [12614265117146095350](https://jules.google.com/task/12614265117146095350) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded the index table click target to the full row on `/` and `/archive` for easier tapping and clicking. Added a row focus outline to improve keyboard navigation.

- **New Features**
  - Full-row click target via CSS only (`position: relative` on `tr`, `::after` on the primary link); secondary links stay independent with higher `z-index`.
  - `:focus-within` outline on the row and subtle hover/focus transform for the trailing link; documented in `.Jules/palette.md`.

<sup>Written for commit 3c9e261292e21cdd04efd43b01685af3a90d5542. Summary will update on new commits. <a href="https://cubic.dev/pr/5L-Labs/5l-labs.com/pull/106?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

