### PR TITLE
⚡ Bolt: [performance improvement] Memoize entries filtering in Archive page

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,7 @@ This journal documents critical performance learnings for the 5L Labs project.
 ## 2026-02-23 - Python HTTP Connection Pooling
 **Learning:** Using standalone `requests.get()` and `requests.post()` in a loop to fetch multiple URLs or hit an API causes a new TCP/TLS handshake per request, leading to massive latency overhead for large jobs.
 **Action:** Always refactor iterative network operations to use a shared `requests.Session()` passed down via arguments to implement Keep-Alive connection pooling.
+
+## 2026-05-17 - React useMemo Caching Regression
+**Learning:** Naively skipping work based on the existence of an output file without checking for source changes (like file hash or ETag) causes regressions by serving stale data.
+**Action:** Never optimize data pipelines by blindly caching outputs; always validate if the source input has been modified before returning cached results.

--- a/src/pages/archive.js
+++ b/src/pages/archive.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
 import { useLocation } from '@docusaurus/router';
@@ -20,7 +20,8 @@ export default function Archive() {
     }
   }, [location.hash]);
 
-  const entries = area === 'all' ? allPosts : allPosts.filter(p => p.area === area);
+  // Optimization: Memoize the filtering calculation so it only runs when area changes
+  const entries = useMemo(() => area === 'all' ? allPosts : allPosts.filter(p => p.area === area), [area]);
 
   return (
     <Layout


### PR DESCRIPTION
### 💡 What
Added `useMemo` hook to memoize the entries filter in the Archive page (`src/pages/archive.js`).

### 🎯 Why
The filter calculation (`allPosts.filter(p => p.area === area)`) was running on every re-render, creating unnecessary overhead, especially as the number of posts grows.

### 📊 Impact
Eliminates redundant array filtering operations, reducing main thread blocking on layout updates and improving React rendering performance when navigating the page without changing the area filter.

### 🔬 Measurement
Verified the frontend functionality remains correct by running the build and visually confirming the Archive page filtering works as expected via Playwright screenshots/videos.

---
*PR created automatically by Jules for task [5561189642184123411](https://jules.google.com/task/5561189642184123411) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoize Archive filtering with React `useMemo` so entries recompute only when `area` changes, improving render performance. Also update `.jules/bolt.md` with caching guidance to validate inputs and avoid stale data.

<sup>Written for commit a1d76cdb5fc152f6912101254078991f6187b3be. Summary will update on new commits. <a href="https://cubic.dev/pr/5L-Labs/5l-labs.com/pull/107?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

