### PR TITLE
🎨 Palette: Improve accessibility of preview controls

### DIFF
--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,0 +1,22 @@
+**💡 What**
+Added accessibility properties to the interactive toggle buttons in the Homepage wireframe preview application. Specifically:
+- Added `aria-pressed` states to the Toolbar view buttons, density tweaks, and annotation tweaks to communicate their active state to screen readers.
+- Added `aria-label`, `title`, and `aria-pressed` to the icon-only color swatches so screen readers can interpret them.
+- Injected `:focus-visible` styles into `sketch.css` to provide a high-contrast visual outline for keyboard navigators inside the preview controls.
+
+**🎯 Why**
+Previously, the interactive toggle buttons and color swatches provided visual cues for selections via CSS changes but omitted semantic `aria-pressed` indicators or accessible labels, making them inaccessible to screen readers. Moreover, keyboard users had no visual feedback to know which element was currently focused.
+
+**📸 Before/After**
+*Before:*
+- Color buttons had no labels: `<button style="background: #1e5f8a;" />`
+- Toggles lacked pressed state: `<button class="on">Tight</button>`
+- Tabbing through controls showed no focus ring.
+
+*After:*
+- Color buttons have labels: `<button style="background: #1e5f8a;" aria-label="Select accent color #1e5f8a" title="Accent color #1e5f8a" aria-pressed="true" />`
+- Toggles communicate state: `<button class="on" aria-pressed="true">Tight</button>`
+- Tabbing clearly highlights the focused control.
+
+**♿ Accessibility**
+Improves keyboard navigation and screen reader comprehension by leveraging standard `aria-*` attributes and providing standard focus-visible rings for interactive components.

--- a/src/components/HomepageRedesign/PreviewApp.jsx
+++ b/src/components/HomepageRedesign/PreviewApp.jsx
@@ -30,7 +30,7 @@ function Toolbar({ view, onSetView }) {
       {buttons.map((b, i) => (
         <React.Fragment key={b.id}>
           {i === 1 && <div className="sep" />}
-          <button className={view === b.id ? 'active' : ''} onClick={() => onSetView(b.id)}>
+          <button className={view === b.id ? 'active' : ''} onClick={() => onSetView(b.id)} aria-pressed={view === b.id}>
             {b.label}
           </button>
         </React.Fragment>
@@ -48,7 +48,7 @@ function TweaksPanel({ tweaks, onTweak }) {
         <label>Density</label>
         <div className="seg">
           {['tight', 'roomy'].map(v => (
-            <button key={v} className={tweaks.density === v ? 'on' : ''} onClick={() => onTweak('density', v)}>
+            <button key={v} className={tweaks.density === v ? 'on' : ''} onClick={() => onTweak('density', v)} aria-pressed={tweaks.density === v}>
               {v.charAt(0).toUpperCase() + v.slice(1)}
             </button>
           ))}
@@ -64,6 +64,9 @@ function TweaksPanel({ tweaks, onTweak }) {
               className={tweaks.accent === c ? 'on' : ''}
               style={{ background: c }}
               onClick={() => onTweak('accent', c)}
+              aria-label={`Select accent color ${c}`}
+              title={`Accent color ${c}`}
+              aria-pressed={tweaks.accent === c}
             />
           ))}
         </div>
@@ -73,7 +76,7 @@ function TweaksPanel({ tweaks, onTweak }) {
         <label>Annotation notes</label>
         <div className="seg">
           {['show', 'hide'].map(v => (
-            <button key={v} className={tweaks.notes === v ? 'on' : ''} onClick={() => onTweak('notes', v)}>
+            <button key={v} className={tweaks.notes === v ? 'on' : ''} onClick={() => onTweak('notes', v)} aria-pressed={tweaks.notes === v}>
               {v.charAt(0).toUpperCase() + v.slice(1)}
             </button>
           ))}

--- a/src/components/HomepageRedesign/sketch.css
+++ b/src/components/HomepageRedesign/sketch.css
@@ -405,3 +405,11 @@
   outline: 2px solid #1a1a1a;
   outline-offset: 2px;
 }
+
+/* Accessibility focus-visible styles for preview toolbar and tweaks panel */
+.wf-preview-root .preview-toolbar button:focus-visible,
+.wf-preview-root .tweaks-panel .seg button:focus-visible,
+.wf-preview-root .tweaks-panel .swatches button:focus-visible {
+  outline: 2px solid #333;
+  outline-offset: 2px;
+}


### PR DESCRIPTION
**💡 What**
Added accessibility properties to the interactive toggle buttons in the Homepage wireframe preview application. Specifically:
- Added `aria-pressed` states to the Toolbar view buttons, density tweaks, and annotation tweaks to communicate their active state to screen readers.
- Added `aria-label`, `title`, and `aria-pressed` to the icon-only color swatches so screen readers can interpret them.
- Injected `:focus-visible` styles into `sketch.css` to provide a high-contrast visual outline for keyboard navigators inside the preview controls.

**🎯 Why**
Previously, the interactive toggle buttons and color swatches provided visual cues for selections via CSS changes but omitted semantic `aria-pressed` indicators or accessible labels, making them inaccessible to screen readers. Moreover, keyboard users had no visual feedback to know which element was currently focused.

**📸 Before/After**
*Before:*
- Color buttons had no labels: `<button style="background: #1e5f8a;" />`
- Toggles lacked pressed state: `<button class="on">Tight</button>`
- Tabbing through controls showed no focus ring.

*After:*
- Color buttons have labels: `<button style="background: #1e5f8a;" aria-label="Select accent color #1e5f8a" title="Accent color #1e5f8a" aria-pressed="true" />`
- Toggles communicate state: `<button class="on" aria-pressed="true">Tight</button>`
- Tabbing clearly highlights the focused control.

**♿ Accessibility**
Improves keyboard navigation and screen reader comprehension by leveraging standard `aria-*` attributes and providing standard focus-visible rings for interactive components.

---
*PR created automatically by Jules for task [7850771392493812261](https://jules.google.com/task/7850771392493812261) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved accessibility of the Homepage preview controls by adding ARIA states, labels for color swatches, and visible focus rings. Screen readers now announce toggle states, and keyboard users can see focus.

- Added aria-pressed to toolbar view buttons, density toggles, and annotation toggles.
- Added aria-label and title to color swatch buttons, plus aria-pressed for the active color.
- Added :focus-visible outlines for toolbar, tweak buttons, and swatches.

<sup>Written for commit 84c4ae7dfc6ef2ac85f5817813acef40860d18fd. Summary will update on new commits. <a href="https://cubic.dev/pr/5L-Labs/5l-labs.com/pull/108?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

