### PR TITLE
⚡ Bolt: [performance improvement] Memoize post filtering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -29,3 +29,7 @@ This journal documents critical performance learnings for the 5L Labs project.
 ## 2023-10-27 - Caching Network I/O
 **Learning:** For batch processing scripts that perform slow network I/O or downstream API calls, not checking if the work has already been done on previous runs leads to redundant requests and N times the API cost.
 **Action:** Always check local file system state (e.g., using `.exists()` on the target output path) and skip operations like fetching remote content if the result is already available locally.
+
+## 2026-02-23 - Memoizing React Render Computations
+**Learning:** In Docusaurus React pages, synchronous list filtering (like iterating through large `allPosts` arrays) on every render is an unnecessary bottleneck when routing causes unrelated state/location changes.
+**Action:** Always wrap derived list computations in `useMemo` when the source array is static or infrequently changing, ensuring filtering only fires when the specific dependency (like a filter category) updates.

--- a/src/pages/archive.js
+++ b/src/pages/archive.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
 import { useLocation } from '@docusaurus/router';
@@ -20,7 +20,8 @@ export default function Archive() {
     }
   }, [location.hash]);
 
-  const entries = area === 'all' ? allPosts : allPosts.filter(p => p.area === area);
+  // ⚡ Bolt Perf: Memoize array filtering to prevent redundant O(N) operations on every component re-render unless the area filter changes.
+  const entries = useMemo(() => area === 'all' ? allPosts : allPosts.filter(p => p.area === area), [area]);
 
   return (
     <Layout

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
@@ -13,7 +13,8 @@ export default function Home() {
   const { siteConfig } = useDocusaurusContext();
   const [area, setArea] = useState('all');
 
-  const filtered = area === 'all' ? allPosts : allPosts.filter(p => p.area === area);
+  // ⚡ Bolt Perf: Memoize array filtering to prevent redundant O(N) operations on every component re-render unless the area filter changes.
+  const filtered = useMemo(() => area === 'all' ? allPosts : allPosts.filter(p => p.area === area), [area]);
   const entries = filtered.slice(0, PREVIEW_COUNT);
   const remaining = filtered.length - PREVIEW_COUNT;
 


### PR DESCRIPTION
What: Wrapped the `allPosts` filtering logic in `src/pages/archive.js` and `src/pages/index.js` with `useMemo`. Added code comments to explain the performance optimization.

Why: The filtering operation recalculates on every render needlessly (e.g. from routing or context updates) unless the selected `area` actually changes.

Impact: Eliminates redundant O(N) filtering operations of the full post array on every component re-render.

Measurement: Load the homepage/archive page and observe reduced JS execution time during re-renders in performance profiling.

---
*PR created automatically by Jules for task [17496358478268530490](https://jules.google.com/task/17496358478268530490) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoized filtering of the `allPosts` array on the Home (`src/pages/index.js`) and Archive (`src/pages/archive.js`) pages using React `useMemo`, so we only recompute when the `area` filter changes. This removes redundant O(N) work on re-renders and improves page responsiveness; added a short note to `.jules/bolt.md`.

<sup>Written for commit afedccc3d6da534964e82029c9f9ff1a2672f436. Summary will update on new commits. <a href="https://cubic.dev/pr/5L-Labs/5l-labs.com/pull/109?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

