### PR TITLE
Add Hermes Bot as guest author

### DIFF
--- a/blog-applied-ai-engineering/authors.yml
+++ b/blog-applied-ai-engineering/authors.yml
@@ -9,3 +9,9 @@ kol:
   title: University Student
   url: https://github.com/KentaLange
   image_url: https://github.com/KentaLange.png
+
+hermes:
+  name: 5L Labs - Hermes Bot (AI)
+  title: AI Agent Contributor
+  url: https://github.com/5L-hermes01
+  image_url: https://github.com/5L-hermes01.png


### PR DESCRIPTION
Adds `5L Labs - Hermes Bot (AI)` as a guest author entry so AI-assisted blog posts can be attributed properly.

Part of the guest contributor workflow test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `hermes` as a guest author so Hermes Bot can be credited on blog posts. Includes name, title, GitHub URL, and avatar.

<sup>Written for commit eaa28eee30ae5e0423e34dd505e2e3c73bbafafb. Summary will update on new commits. <a href="https://cubic.dev/pr/5L-Labs/5l-labs.com/pull/111?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

