### PR TITLE
🎨 Palette: [UX improvement] Hide redundant directional arrows from screen readers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -65,3 +65,6 @@
 ## 2026-05-18 - Expanding Hit Areas for Table Rows
 **Learning:** Having only text as the clickable area within a table row violates Fitts's Law. Wrapping an entire `<tr>` in an `<a>` or `<Link>` tag is invalid HTML and breaks semantic document structure.
 **Action:** Use relative positioned rows (`position: relative` on `tr`) and absolute positioned `::after` pseudo-elements (`inset: 0; position: absolute; z-index: 1`) on the primary link to safely expand the interactive hit area. Pair this with `:focus-within` styles on the entire row and `z-index: 2` on secondary interactive elements within the row.
+## 2026-05-31 - Hiding Redundant Directional Arrows
+**Learning:** Text-based directional arrows (like `→` and `↗`) used inline for visual affordance are read out loud by screen readers, creating annoying auditory clutter (e.g., reading "Start an inquiry rightwards arrow").
+**Action:** Always wrap text-based decorative arrows in `<span aria-hidden="true">` or `<tspan aria-hidden="true">` (if inside an SVG `<text>` block) to hide them from screen readers while preserving the visual UX.

--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,22 +1,4 @@
-**💡 What**
-Added accessibility properties to the interactive toggle buttons in the Homepage wireframe preview application. Specifically:
-- Added `aria-pressed` states to the Toolbar view buttons, density tweaks, and annotation tweaks to communicate their active state to screen readers.
-- Added `aria-label`, `title`, and `aria-pressed` to the icon-only color swatches so screen readers can interpret them.
-- Injected `:focus-visible` styles into `sketch.css` to provide a high-contrast visual outline for keyboard navigators inside the preview controls.
-
-**🎯 Why**
-Previously, the interactive toggle buttons and color swatches provided visual cues for selections via CSS changes but omitted semantic `aria-pressed` indicators or accessible labels, making them inaccessible to screen readers. Moreover, keyboard users had no visual feedback to know which element was currently focused.
-
-**📸 Before/After**
-*Before:*
-- Color buttons had no labels: `<button style="background: #1e5f8a;" />`
-- Toggles lacked pressed state: `<button class="on">Tight</button>`
-- Tabbing through controls showed no focus ring.
-
-*After:*
-- Color buttons have labels: `<button style="background: #1e5f8a;" aria-label="Select accent color #1e5f8a" title="Accent color #1e5f8a" aria-pressed="true" />`
-- Toggles communicate state: `<button class="on" aria-pressed="true">Tight</button>`
-- Tabbing clearly highlights the focused control.
-
-**♿ Accessibility**
-Improves keyboard navigation and screen reader comprehension by leveraging standard `aria-*` attributes and providing standard focus-visible rings for interactive components.
+💡 What: Added `aria-hidden="true"` to text-based directional arrows (`→` and `↗`) used throughout the `HomepageRedesign` components (`Journal`, `Manifesto`, `Schematic`, `Terminal`).
+🎯 Why: Text-based directional arrows provide visual affordance for links, but they are read out loud by screen readers (e.g., reading "Start an inquiry rightwards arrow"), creating confusing auditory clutter. Hiding them preserves the visual UX while vastly improving the screen reader experience.
+📸 Before/After: Visuals remain unchanged.
+♿ Accessibility: Reduces screen reader noise by explicitly hiding decorative text-based symbols.

--- a/src/components/HomepageRedesign/Journal.jsx
+++ b/src/components/HomepageRedesign/Journal.jsx
@@ -93,7 +93,7 @@ export default function Journal() {
               <div className="muted" style={{ fontSize: 13 }}>
                 We split our time between applied consulting and open research. Writing is the main output.
               </div>
-              <div style={{ marginTop: 14 }}><a className="btn">Hire us →</a></div>
+              <div style={{ marginTop: 14 }}><a className="btn">Hire us <span aria-hidden="true">→</span></a></div>
             </div>
 
             <div style={{ marginBottom: 24 }}>
@@ -104,7 +104,7 @@ export default function Journal() {
                 ['Overlord Kill Switch', 'hardware network isolator'],
               ].map(([n, d]) => (
                 <div key={n} style={{ padding: '10px 0', borderBottom: '1px dashed var(--ink-4)' }}>
-                  <div style={{ fontFamily: 'var(--hand)', fontSize: 18 }}>{n} <span className="arrow">↗</span></div>
+                  <div style={{ fontFamily: 'var(--hand)', fontSize: 18 }}>{n} <span className="arrow" aria-hidden="true">↗</span></div>
                   <div className="muted" style={{ fontSize: 12 }}>{d}</div>
                 </div>
               ))}

--- a/src/components/HomepageRedesign/Manifesto.jsx
+++ b/src/components/HomepageRedesign/Manifesto.jsx
@@ -33,7 +33,7 @@ export default function Manifesto() {
           </div>
 
           <div style={{ marginTop: 32, display: 'flex', gap: 14 }}>
-            <a className="btn btn-accent">Hire us for consulting →</a>
+            <a className="btn btn-accent">Hire us for consulting <span aria-hidden="true">→</span></a>
             <a className="btn btn-ghost">See the research</a>
           </div>
 

--- a/src/components/HomepageRedesign/Schematic.jsx
+++ b/src/components/HomepageRedesign/Schematic.jsx
@@ -83,7 +83,7 @@ export default function Schematic() {
 
             {/* Loop arrow: consulting → research */}
             <path d="M 640 340 Q 540 390 380 360 Q 300 340 270 280" fill="none" stroke="var(--ink-3)" strokeWidth="1.2" strokeDasharray="4 4" />
-            <text x="420" y="395" fontFamily="Kalam" fontSize="13" fill="var(--ink-3)">funds the research →</text>
+            <text x="420" y="395" fontFamily="Kalam" fontSize="13" fill="var(--ink-3)">funds the research <tspan aria-hidden="true">→</tspan></text>
           </svg>
 
           <Note top={-20} right={-10} arrow={{
@@ -102,7 +102,7 @@ export default function Schematic() {
             <div style={{ fontFamily: 'var(--hand)', fontSize: 22, lineHeight: 1.1, marginBottom: 10 }}>Four beats, published openly.</div>
             {['Frontier Research', 'Applied AI Engineering', 'Self-Hosted IoT', 'Applied Home ML IoT'].map(x => (
               <div key={x} style={{ padding: '8px 0', borderBottom: '1px dashed var(--ink-4)', fontSize: 14 }}>
-                {x} <span className="arrow">→</span>
+                {x} <span className="arrow" aria-hidden="true">→</span>
               </div>
             ))}
           </div>
@@ -115,7 +115,7 @@ export default function Schematic() {
               ['Overlord Kill Switch', 'hardware isolation'],
             ].map(([n, d]) => (
               <div key={n} style={{ padding: '8px 0', borderBottom: '1px dashed var(--ink-4)' }}>
-                <div style={{ fontSize: 14 }}>{n} <span className="arrow">↗</span></div>
+                <div style={{ fontSize: 14 }}>{n} <span className="arrow" aria-hidden="true">↗</span></div>
                 <div className="muted" style={{ fontSize: 12 }}>{d}</div>
               </div>
             ))}
@@ -128,7 +128,7 @@ export default function Schematic() {
             <div className="muted" style={{ fontSize: 13, marginBottom: 14 }}>
               We take <span className="hi">1–2 engagements per quarter</span>. Private ML, on-device inference, IoT audits.
             </div>
-            <a className="btn btn-accent" style={{ width: '100%', justifyContent: 'center' }}>Start an inquiry →</a>
+            <a className="btn btn-accent" style={{ width: '100%', justifyContent: 'center' }}>Start an inquiry <span aria-hidden="true">→</span></a>
             <div className="muted mono" style={{ fontSize: 10, marginTop: 10, textAlign: 'center' }}>
               NEXT AVAILABILITY — Q3 2026
             </div>

--- a/src/components/HomepageRedesign/Terminal.jsx
+++ b/src/components/HomepageRedesign/Terminal.jsx
@@ -67,7 +67,7 @@ export default function Terminal() {
                   <th key={h} style={{
                     padding: '8px 4px', fontWeight: 500, fontSize: 11, letterSpacing: '0.08em',
                     textAlign: i === 4 ? 'right' : 'left',
-                  }}>{h}</th>
+                  }} aria-hidden={i === 4 ? "true" : undefined}>{h}</th>
                 ))}
               </tr>
             </thead>
@@ -80,7 +80,7 @@ export default function Terminal() {
                   </td>
                   <td style={{ padding: '10px 4px', color: 'var(--ink-3)' }}>{row[2]}</td>
                   <td style={{ padding: '10px 4px', fontFamily: 'var(--hand-tight)', fontSize: 15 }}>{row[3]}</td>
-                  <td style={{ padding: '10px 4px', textAlign: 'right', color: 'var(--ink-3)' }}>{row[4]}</td>
+                  <td style={{ padding: '10px 4px', textAlign: 'right', color: 'var(--ink-3)' }}><span aria-hidden="true">{row[4]}</span></td>
                 </tr>
               ))}
             </tbody>
@@ -118,7 +118,7 @@ export default function Terminal() {
             <div className="muted mono" style={{ fontSize: 11, letterSpacing: '0.1em', marginBottom: 6 }}>
               CURRENT AVAILABILITY: <span className="accent">Q3 2026</span>
             </div>
-            <a className="btn btn-accent">./inquire →</a>
+            <a className="btn btn-accent">./inquire <span aria-hidden="true">→</span></a>
           </div>
         </div>
 

--- a/src/generated/all-posts.json
+++ b/src/generated/all-posts.json
@@ -1,5 +1,23 @@
 [
   {
+    "date": "2026-05-29T00:00:00.000Z",
+    "dateLabel": "2026-05-29",
+    "title": "Anatomy of an AI Agent Skill: The Structure Behind 11 Custom Modules",
+    "area": "applied-ai",
+    "type": "writing",
+    "url": "/applied-ai-engineering/anatomy-of-an-ai-agent-skill",
+    "excerpt": "A field guide to the structure of AI agent skills — the recurring sections, three archetypes, and design philosophy behind 11 custom skill modules that power daily operations."
+  },
+  {
+    "date": "2026-05-24T00:00:00.000Z",
+    "dateLabel": "2026-05-24",
+    "title": "A Shared Latent Space for (Text) Embeddings?",
+    "area": "frontier",
+    "type": "writing",
+    "url": "/frontier-research/shared-latent-embeddings",
+    "excerpt": "Short notes from current work on shared latent spaces and Matryoshka-style embedding layers."
+  },
+  {
     "date": "2026-02-23T00:00:00.000Z",
     "dateLabel": "2026-02-23",
     "title": "Learning about learning?",

--- a/src/generated/latest-post.json
+++ b/src/generated/latest-post.json
@@ -1,6 +1,6 @@
 {
-  "date": "2026-02-23T00:00:00.000Z",
-  "title": "Learning about learning?",
-  "content": "Exploring the limits of Transformer architectures, the Platonic Representation Hypothesis, and the role of curiosity-driven learning in the next generation of AI.",
-  "url": "/frontier-research/learning-again"
+  "date": "2026-05-29T00:00:00.000Z",
+  "title": "Anatomy of an AI Agent Skill: The Structure Behind 11 Custom Modules",
+  "content": "A field guide to the structure of AI agent skills — the recurring sections, three archetypes, and design philosophy behind 11 custom skill modules that power daily operations.",
+  "url": "/applied-ai-engineering/anatomy-of-an-ai-agent-skill"
 }


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to text-based directional arrows (`→` and `↗`) used throughout the `HomepageRedesign` components (`Journal`, `Manifesto`, `Schematic`, `Terminal`).
🎯 Why: Text-based directional arrows provide visual affordance for links, but they are read out loud by screen readers (e.g., reading "Start an inquiry rightwards arrow"), creating confusing auditory clutter. Hiding them preserves the visual UX while vastly improving the screen reader experience.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Reduces screen reader noise by explicitly hiding decorative text-based symbols.

---
*PR created automatically by Jules for task [2950922451696419257](https://jules.google.com/task/2950922451696419257) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide decorative directional arrows from screen readers by wrapping `→` and `↗` in `aria-hidden` spans across `HomepageRedesign` (`Journal`, `Manifesto`, `Schematic`, `Terminal`), including SVG text via `tspan`. Visuals stay the same; screen reader output is cleaner.

<sup>Written for commit ebf22b300ea545a23f2a0cd3a0aac8098d1247ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/5L-Labs/5l-labs.com/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

