### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Stale Embeddings Data Leak

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** When using `requests.get(..., stream=True)`, if the response is not fully consumed and `.close()` is not manually called on all early return paths (like redirect checks or content-type validations), the underlying connection remains open. Over many requests, this leads to connection pool exhaustion and a Denial of Service (DoS).
 **Learning:** Manual resource management (`response.close()`) in python is error-prone, especially when multiple early exit conditions exist in the code.
 **Prevention:** Always wrap `requests.get` (or equivalent network calls) in a `with` statement (context manager) to guarantee the connection is closed when the block exits, regardless of how it exits.
+
+## 2025-05-31 - Stale Embeddings Data Leak
+**Vulnerability:** Skipping embedding regeneration based purely on file existence causes embeddings to become stale. If sensitive data was present in an older version of a page and later removed, the stale embedding retains the sensitive data, leading to a data leak.
+**Learning:** Caching mechanisms for derived data (like embeddings) must validate the source material hasn't changed.
+**Prevention:** Always validate content changes (e.g., via ETag or file hash like SHA-256) before using a cached derived artifact.

--- a/scripts/generate_embeddings.py
+++ b/scripts/generate_embeddings.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import hashlib
 from datetime import datetime
 
 try:
@@ -272,6 +273,7 @@ def save_embedding(
     model: str,
     base_url: str,
     embeddings_dir: str = "embeddings",
+    content_hash: str = None,
 ):
     """
     Saves an individual embedding to a file based on the URL path.
@@ -308,6 +310,9 @@ def save_embedding(
             }
         ],
     }
+
+    if content_hash:
+        embedding_data["metadata"]["content_hash"] = content_hash
 
     # Write to file
     with open(file_path, "w") as f:
@@ -390,7 +395,6 @@ def main():
                 error_count += 1
                 continue
 
-            # Performance Optimization: Check if embedding already exists to avoid network request.
             # Verify containment first so a malformed URL can't probe arbitrary filesystem paths.
             expected_file_path = url_to_file_path(url, replacement_base_url, embeddings_dir)
             try:
@@ -398,10 +402,6 @@ def main():
             except ValueError:
                 logger.warning(f"Skipping {url} - resolved path escapes embeddings dir")
                 error_count += 1
-                continue
-            if expected_file_path.exists():
-                logger.debug(f"Skipping {url} - embedding already exists")
-                skipped_count += 1
                 continue
 
             logger.debug(f"Processing {fetch_url}...")
@@ -414,6 +414,20 @@ def main():
                 error_count += 1
                 continue
 
+            content_hash = hashlib.sha256(content.encode('utf-8')).hexdigest()
+
+            # Security Fix: Hash content to prevent stale embeddings leaking data
+            if expected_file_path.exists():
+                try:
+                    with open(expected_file_path, 'r') as f:
+                        existing_data = json.load(f)
+                    if existing_data.get("metadata", {}).get("content_hash") == content_hash:
+                        logger.debug(f"Skipping {url} - embedding already exists and content is unchanged")
+                        skipped_count += 1
+                        continue
+                except Exception as e:
+                    logger.debug(f"Failed to read/parse existing embedding for {url}: {e}")
+
             embedding = get_embedding(
                 content, api_base, api_key, model, session=session
             )
@@ -425,7 +439,7 @@ def main():
             # Save individual embedding file
             try:
                 save_embedding(
-                    url, embedding, model, replacement_base_url, embeddings_dir
+                    url, embedding, model, replacement_base_url, embeddings_dir, content_hash
                 )
                 success_count += 1
             except Exception as e:


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The embeddings generation script previously relied on file existence checks to avoid regenerating embeddings for identical content. However, this caching mechanism ignored source content updates. If sensitive data was present in an older version of a page and was later removed, the stale embedding would persist, leading to a long-term data leak.
🎯 **Impact:** Exposure of sensitive or retracted information via vector embeddings even after the source data has been removed.
🔧 **Fix:** 
- Added a `content_hash` calculation (using SHA-256) on the fetched page content.
- Updated `save_embedding` to store the hash in the embedding JSON metadata.
- Replaced the naive file-existence check with a logic that compares the computed content hash against the cached metadata hash.
✅ **Verification:** 
- Ran `scripts/verify_security_fixes.py` successfully.
- Code review passed.

---
*PR created automatically by Jules for task [4251597916638828594](https://jules.google.com/task/4251597916638828594) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a critical data leak by preventing stale embeddings from persisting after source content changes. We now hash page content and only reuse cached embeddings when the stored hash matches.

- **Bug Fixes**
  - Compute SHA-256 of fetched content and store as `content_hash` in embedding metadata.
  - Replace file-exists check with hash comparison; regenerate when hash is missing or different.
  - Document the incident and prevention steps in `.jules/sentinel.md`.
  - Verified with `scripts/verify_security_fixes.py`.

<sup>Written for commit a1c4547071686eaca934269b45c8b26da6fb7ae9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/5L-Labs/5l-labs.com/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

