### PR TITLE
🎨 Palette: [UX improvement] Hide redundant decorative arrows from screen readers

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -108,7 +108,7 @@ export default function Home() {
           {remaining > 0 && (
             <div className={styles.loadMore}>
               <Link to={`/archive${area !== 'all' ? `#${area}` : ''}`}>
-                — {remaining} more → full archive —
+                — {remaining} more <span aria-hidden="true">→</span> full archive —
               </Link>
             </div>
           )}
@@ -156,7 +156,7 @@ export default function Home() {
               <span className={styles.availabilityVal}>{consulting.availability}</span>
             </div>
             <Link to={consulting.inquireUrl} className={styles.btnAccent}>
-              ./inquire →
+              ./inquire <span aria-hidden="true">→</span>
             </Link>
           </div>
 

--- a/src/pages/inquiry.js
+++ b/src/pages/inquiry.js
@@ -171,7 +171,7 @@ export default function Inquiry() {
             className={styles.submit}
             disabled={status === 'submitting' || !fields.name || !fields.email || !fields.message || !fields.smsConsent}
           >
-            {status === 'submitting' ? 'Sending…' : './send-inquiry →'}
+            {status === 'submitting' ? 'Sending…' : <>./send-inquiry <span aria-hidden="true">→</span></>}
           </button>
 
         </form>


### PR DESCRIPTION
**What**: Wrapped decorative arrows ("→") in `<span aria-hidden="true">` on `src/pages/index.js` and `src/pages/inquiry.js`.
**Why**: These arrows are purely for visual affordance to indicate a link or submission.
**Accessibility**: Prevents screen readers from announcing "rightwards arrow" in the middle of reading navigation or button text, resulting in a cleaner auditory experience.

---
*PR created automatically by Jules for task [11976317435472071609](https://jules.google.com/task/11976317435472071609) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide decorative arrows from screen readers to improve accessibility and reduce noisy announcements.
Wrapped the "→" characters in <span aria-hidden="true"> on src/pages/index.js and src/pages/inquiry.js.

<sup>Written for commit 469f935181107a9d280fbb85aa0908ae0d1030ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/5L-Labs/5l-labs.com/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

