### PR TITLE
⚡ Bolt: [performance improvement] Optimize PreviewApp React rendering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,7 @@ This journal documents critical performance learnings for the 5L Labs project.
 ## 2026-02-23 - Memoizing React Render Computations
 **Learning:** In Docusaurus React pages, synchronous list filtering (like iterating through large `allPosts` arrays) on every render is an unnecessary bottleneck when routing causes unrelated state/location changes.
 **Action:** Always wrap derived list computations in `useMemo` when the source array is static or infrequently changing, ensuring filtering only fires when the specific dependency (like a filter category) updates.
+
+## 2026-06-07 - React Render Optimization in PreviewApp
+**Learning:** Toggling CSS-only state via React root state updates causes expensive cascading re-renders of large component trees.
+**Action:** Use `React.memo()` to prevent these re-renders and wrap handlers in `useCallback()` to maintain stable references.

--- a/src/components/HomepageRedesign/DesignCanvas.jsx
+++ b/src/components/HomepageRedesign/DesignCanvas.jsx
@@ -9,6 +9,9 @@ const DC = {
   font: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
 };
 
+// ⚡ Bolt Perf: Hoist static string allocation out of render loop to prevent repeated creation
+const gridSvg = `url("data:image/svg+xml,%3Csvg width='120' height='120' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M120 0H0v120' fill='none' stroke='${encodeURIComponent(DC.grid)}' stroke-width='1'/%3E%3C/svg%3E")`;
+
 export function DesignCanvas({ children, minScale = 0.1, maxScale = 8, style = {} }) {
   const vpRef = useRef(null);
   const worldRef = useRef(null);
@@ -106,8 +109,6 @@ export function DesignCanvas({ children, minScale = 0.1, maxScale = 8, style = {
       vp.removeEventListener('pointercancel', onPointerUp);
     };
   }, [apply, minScale, maxScale]);
-
-  const gridSvg = `url("data:image/svg+xml,%3Csvg width='120' height='120' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M120 0H0v120' fill='none' stroke='${encodeURIComponent(DC.grid)}' stroke-width='1'/%3E%3C/svg%3E")`;
 
   return (
     <div

--- a/src/components/HomepageRedesign/PreviewApp.jsx
+++ b/src/components/HomepageRedesign/PreviewApp.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { DesignCanvas, DCSection, DCArtboard } from './DesignCanvas';
 import Manifesto from './Manifesto';
 import Journal from './Journal';
@@ -16,7 +16,8 @@ const TWEAK_DEFAULTS = {
 
 const ACCENT_SWATCHES = ['#c84a1f', '#1e5f8a', '#2a7d4f', '#1a1a1a'];
 
-function Toolbar({ view, onSetView }) {
+// ⚡ Bolt Perf: Memoize Toolbar to prevent re-renders when parent state changes
+const Toolbar = React.memo(function Toolbar({ view, onSetView }) {
   const buttons = [
     { id: 'canvas', label: 'All · canvas' },
     { id: '1',      label: '1 · Manifesto' },
@@ -37,9 +38,10 @@ function Toolbar({ view, onSetView }) {
       ))}
     </div>
   );
-}
+});
 
-function TweaksPanel({ tweaks, onTweak }) {
+// ⚡ Bolt Perf: Memoize TweaksPanel to prevent re-renders when parent state changes
+const TweaksPanel = React.memo(function TweaksPanel({ tweaks, onTweak }) {
   return (
     <div className="tweaks-panel">
       <h5>TWEAKS</h5>
@@ -84,9 +86,10 @@ function TweaksPanel({ tweaks, onTweak }) {
       </div>
     </div>
   );
-}
+});
 
-function CanvasView() {
+// ⚡ Bolt Perf: Memoize CanvasView to prevent expensive re-rendering of the entire canvas
+const CanvasView = React.memo(function CanvasView() {
   return (
     <DesignCanvas>
       <DCSection
@@ -108,9 +111,10 @@ function CanvasView() {
       </DCSection>
     </DesignCanvas>
   );
-}
+});
 
-function SingleView({ which }) {
+// ⚡ Bolt Perf: Memoize SingleView to prevent re-rendering when tweaking CSS state
+const SingleView = React.memo(function SingleView({ which }) {
   const components = { '1': Manifesto, '2': Journal, '3': Terminal, '4': Schematic };
   const Comp = components[which];
   return (
@@ -120,7 +124,7 @@ function SingleView({ which }) {
       </div>
     </div>
   );
-}
+});
 
 export default function PreviewApp() {
   const rootRef = useRef(null);
@@ -131,14 +135,15 @@ export default function PreviewApp() {
 
   const [tweaks, setTweaks] = useState(TWEAK_DEFAULTS);
 
-  const handleSetView = (v) => {
+  // ⚡ Bolt Perf: Wrap handlers in useCallback to provide stable references to memoized children
+  const handleSetView = useCallback((v) => {
     try { localStorage.setItem(LS_VIEW, v); } catch {}
     setView(v);
-  };
+  }, []);
 
-  const handleTweak = (key, value) => {
+  const handleTweak = useCallback((key, value) => {
     setTweaks(prev => ({ ...prev, [key]: value }));
-  };
+  }, []);
 
   // Apply tweaks via CSS custom properties and class toggles on the root element
   useEffect(() => {


### PR DESCRIPTION
**What:**
- Wrapped `Toolbar`, `TweaksPanel`, `CanvasView`, and `SingleView` components in `src/components/HomepageRedesign/PreviewApp.jsx` with `React.memo()`.
- Wrapped `handleSetView` and `handleTweak` handlers in `useCallback()`.
- Hoisted the `gridSvg` template string allocation in `src/components/HomepageRedesign/DesignCanvas.jsx` out of the render loop to the module scope.

**Why:**
- Toggling CSS-only state (like density and accent colors) via React root state updates in `PreviewApp` caused expensive cascading re-renders across the entire wireframe app tree.
- Repeated static string allocations inside `DesignCanvas` added unnecessary memory pressure during zooming and panning.

**Impact:**
- Significantly reduces React reconciliation overhead and drops unneeded component re-renders to near zero when changing UI tweaks or toolbar tabs.
- Eliminates repeated string allocations during interactions.

**Measurement:**
- Verify by using the React DevTools Profiler and interacting with the `TweaksPanel` or toolbar; note that the large canvas views no longer re-render when changing UI settings.

---
*PR created automatically by Jules for task [3198790443861949743](https://jules.google.com/task/3198790443861949743) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimizes `PreviewApp` rendering by memoizing heavy views and stabilizing handlers, plus hoists a static grid string in `DesignCanvas` to cut work during interactions. This reduces unnecessary re-renders and lowers memory churn when changing tweaks or panning/zooming.

- **Refactors**
  - Wrapped `Toolbar`, `TweaksPanel`, `CanvasView`, and `SingleView` with `React.memo()` to prevent cascading re-renders on CSS-only state changes.
  - Wrapped `handleSetView` and `handleTweak` in `useCallback()` to keep stable prop references.
  - Hoisted `gridSvg` out of `DesignCanvas` render to avoid repeated string allocations.

<sup>Written for commit 885e439b76263058852dc101a197df05e87fec5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/5L-Labs/5l-labs.com/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

