### PR TITLE
🎨 Palette: [UX improvement] Hide inline decorative arrows from screen readers

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -108,7 +108,7 @@ export default function Home() {
           {remaining > 0 && (
             <div className={styles.loadMore}>
               <Link to={`/archive${area !== 'all' ? `#${area}` : ''}`}>
-                — {remaining} more → full archive —
+                — {remaining} more <span aria-hidden="true">→</span> full archive —
               </Link>
             </div>
           )}
@@ -156,7 +156,7 @@ export default function Home() {
               <span className={styles.availabilityVal}>{consulting.availability}</span>
             </div>
             <Link to={consulting.inquireUrl} className={styles.btnAccent}>
-              ./inquire →
+              ./inquire <span aria-hidden="true">→</span>
             </Link>
           </div>
 

--- a/src/pages/inquiry.js
+++ b/src/pages/inquiry.js
@@ -61,7 +61,7 @@ export default function Inquiry() {
             <h1>Got it.</h1>
             <p>We'll be in touch at <strong>{fields.email}</strong>.</p>
             <p className={styles.muted}>We take on 1–2 engagements per quarter — expect a response within a few business days.</p>
-            <Link to="/" className={styles.backLink}>← back to home</Link>
+            <Link to="/" className={styles.backLink}><span aria-hidden="true">←</span> back to home</Link>
           </div>
         </main>
       </Layout>
@@ -171,7 +171,7 @@ export default function Inquiry() {
             className={styles.submit}
             disabled={status === 'submitting' || !fields.name || !fields.email || !fields.message || !fields.smsConsent}
           >
-            {status === 'submitting' ? 'Sending…' : './send-inquiry →'}
+            {status === 'submitting' ? 'Sending…' : <>./send-inquiry <span aria-hidden="true">→</span></>}
           </button>
 
         </form>

--- a/update_palette.py
+++ b/update_palette.py
@@ -1,0 +1,19 @@
+import os
+from datetime import datetime
+
+file_path = '.Jules/palette.md'
+new_entry = f"""
+## {datetime.now().strftime('%Y-%m-%d')} - Hiding Redundant Directional Arrows
+**Learning:** Text-based directional arrows (like `→` and `←`) used inline for visual affordance are read out loud by screen readers, creating annoying auditory clutter (e.g., reading "Start an inquiry rightwards arrow").
+**Action:** Always wrap text-based decorative arrows in `<span aria-hidden="true">` or `<tspan aria-hidden="true">` (if inside an SVG `<text>` block) to hide them from screen readers while preserving the visual UX.
+"""
+
+if os.path.exists(file_path):
+    with open(file_path, 'r') as f:
+        content = f.read()
+    if "Hiding Redundant Directional Arrows" not in content:
+        with open(file_path, 'a') as f:
+            f.write(new_entry)
+else:
+    with open(file_path, 'w') as f:
+        f.write(new_entry)


### PR DESCRIPTION
💡 What: Wrapped inline decorative arrows (like `→` and `←`) in `<span aria-hidden="true">` tags in `src/pages/index.js` and `src/pages/inquiry.js`.
🎯 Why: Screen readers read text-based directional arrows out loud, which creates auditory clutter. Hiding them preserves the visual affordance while improving the accessibility for screen reader users.
♿ Accessibility: Screen reader users will no longer hear redundant directional cues like "rightwards arrow" or "leftwards arrow".

---
*PR created automatically by Jules for task [5820394479298058279](https://jules.google.com/task/5820394479298058279) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide decorative arrows from screen readers by wrapping `→` and `←` in `<span aria-hidden="true">` on `src/pages/index.js` and `src/pages/inquiry.js`, reducing noisy announcements and improving accessibility. Added `update_palette.py` to append this guideline to `.Jules/palette.md` for future reference.

<sup>Written for commit f727701c9c3daf64ad8859e18746b37b2a18aefd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/5L-Labs/5l-labs.com/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

