### PR TITLE
⚡ Bolt: Memoize CanvasView and SingleView in PreviewApp

### DIFF
--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,4 +1,7 @@
-💡 What: Added `aria-hidden="true"` to text-based directional arrows (`→` and `↗`) used throughout the `HomepageRedesign` components (`Journal`, `Manifesto`, `Schematic`, `Terminal`).
-🎯 Why: Text-based directional arrows provide visual affordance for links, but they are read out loud by screen readers (e.g., reading "Start an inquiry rightwards arrow"), creating confusing auditory clutter. Hiding them preserves the visual UX while vastly improving the screen reader experience.
-📸 Before/After: Visuals remain unchanged.
-♿ Accessibility: Reduces screen reader noise by explicitly hiding decorative text-based symbols.
+💡 What: Wrapped `CanvasView` and `SingleView` components in `React.memo()` in `src/components/HomepageRedesign/PreviewApp.jsx`.
+
+🎯 Why: To prevent expensive cascading re-renders. The `PreviewApp` component contains root-level state for CSS tweaks (like density, accent colors, and note visibility) that change frequently when a user interacts with the sidebar. Because `CanvasView` renders four highly complex wireframe components simultaneously, not memoizing it meant that a simple CSS class toggle at the root was causing all four heavy components to fully re-render synchronously.
+
+📊 Impact: Reduces completely unnecessary React reconciliation and re-render cycles for the heavy `Manifesto`, `Journal`, `Terminal`, and `Schematic` components to 0 when interacting with isolated CSS toggles. This prevents frame dropping on lower-end devices during these tweaks.
+
+🔬 Measurement: Verify by rendering `<PreviewApp />` with React DevTools profiler enabled. Toggle the "Density" or "Accent" controls. Notice that the entire `CanvasView` sub-tree skips rendering.

--- a/src/components/HomepageRedesign/PreviewApp.jsx
+++ b/src/components/HomepageRedesign/PreviewApp.jsx
@@ -86,7 +86,8 @@ function TweaksPanel({ tweaks, onTweak }) {
   );
 }
 
-function CanvasView() {
+// ⚡ Bolt Perf: Wrap heavy CanvasView in React.memo to prevent expensive cascading re-renders when tweaking CSS state at the root level.
+const CanvasView = React.memo(function CanvasView() {
   return (
     <DesignCanvas>
       <DCSection
@@ -108,9 +109,10 @@ function CanvasView() {
       </DCSection>
     </DesignCanvas>
   );
-}
+});
 
-function SingleView({ which }) {
+// ⚡ Bolt Perf: Wrap SingleView in React.memo to prevent unnecessary re-renders when isolated root state updates.
+const SingleView = React.memo(function SingleView({ which }) {
   const components = { '1': Manifesto, '2': Journal, '3': Terminal, '4': Schematic };
   const Comp = components[which];
   return (
@@ -120,7 +122,7 @@ function SingleView({ which }) {
       </div>
     </div>
   );
-}
+});
 
 export default function PreviewApp() {
   const rootRef = useRef(null);


### PR DESCRIPTION
💡 What: Wrapped `CanvasView` and `SingleView` components in `React.memo()` in `src/components/HomepageRedesign/PreviewApp.jsx`.

🎯 Why: To prevent expensive cascading re-renders. The `PreviewApp` component contains root-level state for CSS tweaks (like density, accent colors, and note visibility) that change frequently when a user interacts with the sidebar. Because `CanvasView` renders four highly complex wireframe components simultaneously, not memoizing it meant that a simple CSS class toggle at the root was causing all four heavy components to fully re-render synchronously.

📊 Impact: Reduces completely unnecessary React reconciliation and re-render cycles for the heavy `Manifesto`, `Journal`, `Terminal`, and `Schematic` components to 0 when interacting with isolated CSS toggles. This prevents frame dropping on lower-end devices during these tweaks.

🔬 Measurement: Verify by rendering `<PreviewApp />` with React DevTools profiler enabled. Toggle the "Density" or "Accent" controls. Notice that the entire `CanvasView` sub-tree skips rendering.

---
*PR created automatically by Jules for task [6672446153413864968](https://jules.google.com/task/6672446153413864968) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoized `CanvasView` and `SingleView` in `PreviewApp` to stop cascading re-renders when toggling density, accent, or note visibility. This keeps the four heavy wireframe views from re-rendering and smooths interactions, especially on low-end devices.

- **Refactors**
  - Wrapped `CanvasView` and `SingleView` with `React.memo()` in `src/components/HomepageRedesign/PreviewApp.jsx`.
  - Prevents re-renders of `Manifesto`, `Journal`, `Terminal`, and `Schematic` when only root CSS state changes.

<sup>Written for commit 3d3b07ada9a264eb8500db052fb573542155415c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/5L-Labs/5l-labs.com/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

