### PR TITLE
🎨 Palette: [UX improvement] Hide redundant directional arrows from screen readers

### DIFF
--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,4 +1,7 @@
-💡 What: Added `aria-hidden="true"` to text-based directional arrows (`→` and `↗`) used throughout the `HomepageRedesign` components (`Journal`, `Manifesto`, `Schematic`, `Terminal`).
-🎯 Why: Text-based directional arrows provide visual affordance for links, but they are read out loud by screen readers (e.g., reading "Start an inquiry rightwards arrow"), creating confusing auditory clutter. Hiding them preserves the visual UX while vastly improving the screen reader experience.
-📸 Before/After: Visuals remain unchanged.
-♿ Accessibility: Reduces screen reader noise by explicitly hiding decorative text-based symbols.
+💡 What: Added an `aria-label` to the "DATE" chip indicating the descending sort order and applied `aria-hidden="true"` to the redundant downward arrow `↓` in `src/components/HomepageRedesign/Terminal.jsx`.
+
+🎯 Why: Screen readers announce inline directional arrows used for visual cues (e.g., reading "downwards arrow"), causing auditory clutter and confusing navigation. Furthermore, merely hiding the arrow removes semantic sorting context for non-visual users.
+
+📸 Before/After: Visual UI remains unchanged. The change happens in the DOM.
+
+♿ Accessibility: Ensures that screen reader users hear clear sorting context ("Sorted by date descending") instead of annoying and contextless "downwards arrow" announcements, aligning with our journal's best practices for directional arrows.

--- a/src/components/HomepageRedesign/Terminal.jsx
+++ b/src/components/HomepageRedesign/Terminal.jsx
@@ -56,7 +56,7 @@ export default function Terminal() {
             <div className="mono" style={{ fontSize: 11, letterSpacing: '0.14em', color: 'var(--ink-3)' }}>
               INDEX OF /&nbsp;·&nbsp;SORT BY:
             </div>
-            <span className="chip chip-accent">DATE ↓</span>
+            <span className="chip chip-accent" aria-label="Sorted by date descending">DATE <span aria-hidden="true">↓</span></span>
             <span className="chip">AREA</span>
             <span className="chip">TYPE</span>
           </div>


### PR DESCRIPTION
💡 What: Added an `aria-label` to the "DATE" chip indicating the descending sort order and applied `aria-hidden="true"` to the redundant downward arrow `↓` in `src/components/HomepageRedesign/Terminal.jsx`.

🎯 Why: Screen readers announce inline directional arrows used for visual cues (e.g., reading "downwards arrow"), causing auditory clutter and confusing navigation. Furthermore, merely hiding the arrow removes semantic sorting context for non-visual users.

📸 Before/After: Visual UI remains unchanged. The change happens in the DOM.

♿ Accessibility: Ensures that screen reader users hear clear sorting context ("Sorted by date descending") instead of annoying and contextless "downwards arrow" announcements, aligning with our journal's best practices for directional arrows.

---
*PR created automatically by Jules for task [586094860001100028](https://jules.google.com/task/586094860001100028) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves screen reader clarity by adding `aria-label="Sorted by date descending"` to the DATE chip and marking the visual arrow `↓` as `aria-hidden="true"`. Visual UI is unchanged; screen readers now announce the sort state instead of reading the arrow.

<sup>Written for commit c3ae845674a621f560da1978b9241b0d04e3c17b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/5L-Labs/5l-labs.com/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

