### PR TITLE
Add Docker/ScalaHost deployment and health check

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+build
+.docusaurus
+.git
+.github
+.gitignore
+.gitmodules
+Dockerfile
+README.md
+*.log
+.DS_Store
+embeddings
+.venv
+src/generated

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Stage 1: Build
+FROM oven/bun:1-alpine AS builder
+
+WORKDIR /app
+
+# Copy package files
+COPY package.json bun.lock ./
+
+# Install dependencies
+RUN bun install --frozen-lockfile
+
+# Copy source code
+COPY . .
+
+# Build the site
+# Note: This script assumes 'embeddings' directory is populated (e.g. via git submodule update)
+RUN bun run build
+
+# Stage 2: Serve
+FROM nginx:alpine
+
+# Copy built assets from builder stage
+COPY --from=builder /app/build /usr/share/nginx/html
+
+# Expose port 80
+EXPOSE 80
+
+# Start Nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/deployment/scalahost/5l-labs.container
+++ b/deployment/scalahost/5l-labs.container
@@ -1,0 +1,13 @@
+[Unit]
+Description=5L Labs Website Container
+After=network-online.target
+
+[Container]
+Image=ghcr.io/5l-labs/5l-labs.com:latest
+ContainerName=5l-labs-website
+PublishPort=8080:80
+# Auto-update the image if a new version is pushed
+AutoUpdate=registry
+
+[Install]
+WantedBy=default.target

--- a/scripts/deploy-scalahost.sh
+++ b/scripts/deploy-scalahost.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+# Configuration
+QUADLET_NAME="5l-labs.container"
+SOURCE_PATH="./deployment/scalahost/$QUADLET_NAME"
+DEST_DIR="$HOME/.config/containers/systemd"
+SERVICE_NAME="5l-labs"
+
+echo "Deploying 5l-labs to ScalaHost (Podman/Quadlet)..."
+
+# 1. Ensure destination directory exists
+mkdir -p "$DEST_DIR"
+
+# 2. Copy Quadlet file
+echo "Copying $QUADLET_NAME to $DEST_DIR..."
+cp "$SOURCE_PATH" "$DEST_DIR/"
+
+# 3. Reload systemd user daemon
+echo "Reloading systemd --user daemon..."
+systemctl --user daemon-reload
+
+# 4. Enable lingering (requires sudo if not already enabled for user, or run by admin)
+# Attempt to enable linger for current user if loginctl is available
+if command -v loginctl >/dev/null 2>&1; then
+    if ! loginctl show-user $USER --property=Linger | grep -q "yes"; then
+        echo "Attempting to enable linger for $USER (may prompt for password)..."
+        loginctl enable-linger $USER || echo "Warning: Failed to enable linger. Service may stop when you log out."
+    else
+        echo "Linger is already enabled for $USER."
+    fi
+else
+    echo "Warning: loginctl not found. Make sure lingering is enabled for long-running services."
+fi
+
+# 5. Start/Restart service
+echo "Starting/Restarting $SERVICE_NAME.service..."
+systemctl --user restart "$SERVICE_NAME.service"
+
+echo "Deployment complete! Check status with: systemctl --user status $SERVICE_NAME.service"

--- a/static/health.json
+++ b/static/health.json
@@ -1,0 +1,5 @@
+{
+    "status": "ok",
+    "service": "5l-labs.com",
+    "version": "1.0.0"
+}


### PR DESCRIPTION
## Summary
- Resurrects the original `deployment/observability` work (fell ~154 commits behind main) onto current main
- Adds a Dockerfile + `.dockerignore`, a ScalaHost/Podman Quadlet unit, a deploy script, and a static `/health.json` endpoint

## Notes
- Updated the Dockerfile's build stage from `npm ci`/`npm run build` to `bun install`/`bun run build` since the repo standardized on bun after the original branch was written
- Everything else carried over unchanged from the original branch

## Test plan
- [ ] `docker build .` succeeds
- [ ] Container serves the site and `/health.json` returns 200
- [ ] `scripts/deploy-scalahost.sh` installs and starts the Quadlet unit on the target host

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds containerized deployment (Docker + Podman Quadlet) and a static /health.json, rebasing the original deployment work onto main. Builds with `bun` and serves via `nginx` for easy ScalaHost deploys and health checks.

- **New Features**
  - Dockerfile builds with `bun` and serves static site via `nginx:alpine`.
  - `.dockerignore` trims build context.
  - Quadlet unit (`deployment/scalahost/5l-labs.container`) publishes 8080:80 and auto-updates from `ghcr.io/5l-labs/5l-labs.com:latest`.
  - `scripts/deploy-scalahost.sh` installs/restarts the user service and enables linger when possible.
  - Adds `/health.json` returning 200 for probes.

<sup>Written for commit b6948c57e28c49403d7ed0f13cc795553514c8ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/5L-Labs/5l-labs.com/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

